### PR TITLE
Add .gitignore to ignore VSCode maven plugin files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+target/
+.idea
+
+step/
+.classpath
+.project
+.settings/
+.factorypath

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,4 @@
-target/
-.idea
-
-step/
+# Remove auto-generated files from 'Maven for Java' vscode extension.
 .classpath
 .project
 .settings/


### PR DESCRIPTION
See title. 

All podmates are using VSCode with the 'Maven for Java' extension. This extension automatically adds files that should not be committed to the repo. Thus, those file types should be added to .gitignore file.
