### PR TITLE
Time, part 3: Update times in database.

### DIFF
--- a/frontend/src/components/Utils/time.js
+++ b/frontend/src/components/Utils/time.js
@@ -80,11 +80,13 @@ export function timezonesForCountry(countryName) {
 }
 
 /**
- * NOTE TO SEL FREMEMBER TEST TIMEZOE=''
- * @param {string} msTimestamp Milliseconds since epoch
- * @param {string} timezone The timezone
+ * Get a date in 'YYYY-MM-DD' format. 
+ * 
+ * @param {string} msTimestamp Timestamp, in milliseconds since epoch.
+ * @param {string} timezone The timezone which the string should be returned in.
+ * @returns {string} The date in 'YYYY-MM-DD' format. 
  */
-export function getDateBarebones(msTimestamp, timezone = null) {
+export function getDateBarebones(msTimestamp, timezone=null) {
   if (timezone === null) {
     return moment.tz(parseFloat(msTimestamp), '').format('YYYY-MM-DD');
   }
@@ -92,9 +94,11 @@ export function getDateBarebones(msTimestamp, timezone = null) {
 }
 
 /**
- * SAME NOTE
- * @param {string} msTimestamp Milliseconds since epoch
- * @param {string} timezone The timezone.
+ * Get a time in 24-hour ('HH:mm') format. 
+ * 
+ * @param {string} msTimestamp Timestamp, in milliseconds since epoch.
+ * @param {string} timezone The timezone which the string should be returned in.
+ * @returns {string} The time in 24-hour (HH:mm) format.   
  */
 export function get24hTime(msTimestamp, timezone=null) {
   if (timezone === null) {
@@ -104,11 +108,12 @@ export function get24hTime(msTimestamp, timezone=null) {
 }
 
 /**
- * TODO
- * 
- * @param {*} time 
- * @param {*} date 
- * @param {*} tz 
+ * Get a Firebase Timestamp object for time.
+ *
+ * @param {string} time The time in 'HH:mm' format.
+ * @param {string} date The date in 'YYYY-MM-DD' format.
+ * @param {string} tz The timezone in which the date takes place.
+ * @returns {firestore.Timestamp} Firestore timestamp object at the same time. 
  */
 export function getFirebaseTime(time, date, tz) {
   const mtzDate = moment.tz(time + " " + date, "HH:mm YYYY-MM-DD", tz);

--- a/frontend/src/components/Utils/time.test.js
+++ b/frontend/src/components/Utils/time.test.js
@@ -95,9 +95,16 @@ test('other date barebones format', () => {
   const actualSingapore = utils.getDateBarebones(testDate, TZ_SINGAPORE);
   expect(actualCentral).toEqual(expectedCentral);
   expect(actualSingapore).toEqual(expectedSingapore);
-})
+});
 
-test('UTC time barebones format', () => {
+test('24h crazy queries', () => {  
+  const testDate = new Date(Date.UTC(2020, 7, 23, 2, 3, 2, 4)).getTime();
+  const expected = "02:03";
+  expect(utils.get24hTime(testDate, '')).toBe(expected);
+  expect(utils.get24hTime(testDate, null)).toBe(expected);
+});
+
+test('UTC time 24h format', () => {
   // Month parameter is zero indexed so it's actually the 10th month.
   const testDate = new Date(Date.UTC(2020, 9, 3, 14, 19, 4, 23)).getTime();
   const expected = '14:19';
@@ -105,7 +112,7 @@ test('UTC time barebones format', () => {
   expect(actual).toEqual(expected);
 });
 
-test('other time barebones format', () => {
+test('other time 24h format', () => {
   const testDate = new Date(Date.UTC(2020, 7, 23, 2, 3, 2, 4)).getTime();
   const expectedCentral = '21:03';
   const expectedSingapore = '10:03';
@@ -115,13 +122,9 @@ test('other time barebones format', () => {
   expect(actualSingapore).toEqual(expectedSingapore);
 })
 
-test('firestore Timestamp format', () => {
-  const testDate = new Date(Date.UTC(2020, 7, 23, 2, 3))
-  // central = 'Saturday, August 22, 2020, 9:03 PM';
-  // singapore = 'Sunday, August 23, 2020, 10:03 AM';
-  const actualCentral = utils.getFirebaseTime("21:03", "2020-08-22", TZ_CHICAGO)
-  const actualSingapore = utils.getFirebaseTime("10:03", "2020-08-23", TZ_SINGAPORE);
-  console.log(actualCentral);
-  expect(actualCentral.toDate().getTime()).toEqual(testDate.getTime());
-  expect(actualSingapore.toDate()).toEqual(testDate);
-});
+test('barebones crazy queries', () => {  
+  const testDate = new Date(Date.UTC(2020, 7, 23, 2, 3, 2, 4)).getTime();
+  const expected = "2020-08-23";
+  expect(utils.getDateBarebones(testDate, '')).toBe(expected);
+  expect(utils.getDateBarebones(testDate, null)).toBe(expected);
+})

--- a/frontend/src/components/Utils/time.test.js
+++ b/frontend/src/components/Utils/time.test.js
@@ -128,3 +128,14 @@ test('barebones crazy queries', () => {
   expect(utils.getDateBarebones(testDate, '')).toBe(expected);
   expect(utils.getDateBarebones(testDate, null)).toBe(expected);
 })
+
+test('firestore Timestamp format', () => {
+  const testDate = new Date(Date.UTC(2020, 7, 23, 2, 3))
+  // central = 'Saturday, August 22, 2020, 9:03 PM';
+  // singapore = 'Sunday, August 23, 2020, 10:03 AM';
+  const actualCentral = utils.getFirebaseTime("21:03", "2020-08-22", TZ_CHICAGO)
+  const actualSingapore = utils.getFirebaseTime("10:03", "2020-08-23", TZ_SINGAPORE);
+  console.log(actualCentral);
+  expect(actualCentral.toDate().getTime()).toEqual(testDate.getTime());
+  expect(actualSingapore.toDate()).toEqual(testDate);
+});

--- a/frontend/src/components/ViewActivities/activity.js
+++ b/frontend/src/components/ViewActivities/activity.js
@@ -51,8 +51,6 @@ class Activity extends React.Component {
             {utils.getField(activity, DB.ACTIVITIES_START_COUNTRY, '', ' at ')}</p>
           <p>End time: {time.timestampToFormatted(activity[DB.ACTIVITIES_END_TIME])} 
             {utils.getField(activity, DB.ACTIVITIES_END_COUNTRY, '', ' at ')}</p>
-          <p>start: {utils.getField(activity, DB.ACTIVITIES_START_TZ)}</p>  
-          <p>end: {utils.getField(activity, DB.ACTIVITIES_END_TZ)}</p> 
         </Card.Body>
       );
     } else { // Edit mode.

--- a/frontend/src/components/ViewActivities/activityfns.js
+++ b/frontend/src/components/ViewActivities/activityfns.js
@@ -47,7 +47,6 @@ export function compareActivities(a, b) {
 
 /**
  * Get the field of field name `fieldName` from `activity  or the default value.
- * TODO: 3RD ARG NULL TESTS
  * 
  * @param {Object} activity 
  * @param {string} fieldName 

--- a/frontend/src/components/ViewActivities/activityfns.js
+++ b/frontend/src/components/ViewActivities/activityfns.js
@@ -88,3 +88,18 @@ export async function writeActivity(tripId, activityId, newValues) {
     return false;
   }
 }
+
+/**
+ * Get the value of a reference. 
+ * 
+ * @param {Reference} ref Reference to get the value of.
+ * @param {string} ignoreValue The "null" or "none" value that ref could be.
+ * @param {string} defaultValue Value to return if ref.current.value === ignoreValue.
+ * @returns defaultValue if ref.current.value === ignoreValue, else ref.current.value.
+ */
+export function getRefValue(ref, ignoreValue, defaultValue=null) {
+  if (ref.current.value === ignoreValue) {
+    return defaultValue;
+  } 
+  return ref.current.value;
+}

--- a/frontend/src/components/ViewActivities/activityfns.test.js
+++ b/frontend/src/components/ViewActivities/activityfns.test.js
@@ -98,4 +98,5 @@ test('getField', () => {
   expect(activityFns.getField(activity, 'field2', 4)).toBe(4);
   expect(activityFns.getField(activity, 'field1', 'nooo', 'aww ')).toBe('aww yes');
   expect(activityFns.getField(activity, 'field2', 4, ' and')).toBe(4);
+  expect(activityFns.getField(activity, 'field2')).toBeNull();
 })

--- a/frontend/src/components/ViewActivities/activityfns.test.js
+++ b/frontend/src/components/ViewActivities/activityfns.test.js
@@ -1,5 +1,6 @@
 import * as activityFns from './activityfns.js';
 import { getActivityList } from './activitylist.js';
+import { get24hTime } from '../Utils/time.js';
 
 const ten = new Date(Date.UTC(2020, 4, 2, 10,  0));          // May 2, 2020 10:00
 const eleven = new Date(Date.UTC(2020, 4, 2, 11, 0));        // May 2, 2020 11:00
@@ -100,3 +101,11 @@ test('getField', () => {
   expect(activityFns.getField(activity, 'field2', 4, ' and')).toBe(4);
   expect(activityFns.getField(activity, 'field2')).toBeNull();
 })
+
+test('getRefValue', () => {
+  const fakeRef = {current: {value: 'parasailing!'}};
+  expect(activityFns.getRefValue(fakeRef, 'parasailing!')).toBeNull();
+  expect(activityFns.getRefValue(fakeRef, 'parasailing!', 'swimming.')).toBe('swimming.');
+  expect(activityFns.getRefValue(fakeRef, 'swimming')).toBe('parasailing!');
+  expect(activityFns.getRefValue(fakeRef, 'swimming', 'jumping')).toBe('parasailing!');
+});

--- a/frontend/src/components/ViewActivities/editActivity.js
+++ b/frontend/src/components/ViewActivities/editActivity.js
@@ -75,17 +75,17 @@ class EditActivity extends React.Component {
     newVals[DB.ACTIVITIES_END_TZ] = getRefValue(this.editEndTzRef, '', '');
 
     // Start time fields!
-    // let newStart = {};
-    // if (this.editStartTimeRef.current.value !== '') {
-    //   newStart[DB.ACTIVITIES_START_TIME] = this.editStartTimeRef.current.value;
-    // }
-    // if (this.editStartDateRef.current.value !== '') {
-    //   newStart[DB.ACTIVITIES_START_DATE] = this.editStartDateRef.current.value;
-    // }
-    // newStart[DB.ACTIVITIES_START_TIME] = this.startTzRef.current.value;
-    // newVals[DB.ACTIVITIES_START_TIME] = time.getFirebaseTime(newStart);
+    const startTime = getRefValue(this.editStartTimeRef, '');
+    const startDate = getRefValue(this.editStartDateRef, '');
+    const startTz = newVals[DB.ACTIVITIES_START_TZ];
+    newVals[DB.ACTIVITIES_START_TIME] = time.getFirebaseTime(startTime, startDate, startTz);
 
-    console.log("writing...", newVals)
+    // End time fields!
+    const endTime = getRefValue(this.editEndTimeRef, '');
+    const endDate = getRefValue(this.editEndDateRef, '');
+    const endTz = newVals[DB.ACTIVITIES_END_TZ];
+    newVals[DB.ACTIVITIES_END_TIME] = time.getFirebaseTime(endTime, endDate, endTz);
+
     writeActivity(this.props.activity.tripId, this.props.activity.id, newVals);
   }
 

--- a/frontend/src/components/ViewActivities/editActivity.js
+++ b/frontend/src/components/ViewActivities/editActivity.js
@@ -1,27 +1,12 @@
 import React from 'react';
 import { Button, Col, Form, Row, FormControl } from 'react-bootstrap';
-import { getField, writeActivity } from './activityfns.js';
+import { getField, writeActivity, getRefValue } from './activityfns.js';
 import * as DB from '../../constants/database.js'
 import { countryList } from '../../constants/countries.js';
 import * as time from '../Utils/time.js';
 
 /**
- * Get the value of a reference. 
- * 
- * @param {Reference} ref Reference to get the value of.
- * @param {string} noChangeValue The "null" or "none" value that ref could be.
- * @param {string} defaultValue Value to return if ref.current.value === noChangeValue.
- * @returns defaultValue if ref.current.value === noChangeValue, else ref.current.value.
- */
-function getRefValue(ref, noChangeValue, defaultValue=null) {
-  if (ref.current.value === noChangeValue) {
-    return defaultValue;
-  } 
-  return ref.current.value;
-}
-
-/**
- * The form that's used when the user is editing an activity
+ * The form that's used when the user is editing an activity.
  * 
  * @param {Object} props This component expects the following props:
  * - `activity` The activity to display.
@@ -54,7 +39,6 @@ class EditActivity extends React.Component {
   
   /**
    * Edit an activity in the database upon form submission.
-   * TODO: Update times as well! This only does the text field forms (#64).
    */
   editActivity() {
     const activity = this.props.activity;


### PR DESCRIPTION
### What is a quick description of the change?

Update user-edited times into the database. 

### Is this fixing an issue?

Fixes #64: When someone changes a time, date, or timezone using the "edit" form, the changes are reflected in the database, in the correct timezone.
Fixes #48: Every field in the "edit" form is accounted for.
Fixes #22: Lots of date formatting options! 

### Are there more details that are relevant?

This pull request focuses on putting the changed values of the start and end time, date, and timezone fields correctly into the database, and ensuring they can be queried from the database and displayed correctly and exactly the same. 

### Check lists (check `x` in `[ ]` of list items)

- [x] Test written/updating
- [x] Tests passing
- [x] Coding style (indentation, etc)

Please explain why any are not present, if any.

### Any additional comments?

This PR is the finale of the Time saga! let's hope it doesn't get funded for more series, one was enough...