### PR TITLE
Setup Firebase Admin in the backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ This file structure is largely the same as that used during portfolio creation p
 Servlets developed in the backend must be routed to the prefix `/api/v1` in the `@WebServlet` annotation, e.g.:
 ```
 @WebServlet("/api/v1/test-servlet")
-public class DataServlet extends HttpServlet { ... }
+public class TestServlet extends HttpServlet { ... }
 ```
 
 The servlet can then be accessed from the frontend with a fetch request, e.g. `fetch('api/v1/test-servlet').then( ... )`.

--- a/README.md
+++ b/README.md
@@ -106,6 +106,14 @@ backend/
 ```
 This file structure is largely the same as that used during portfolio creation portion of Google's 2020 STEP internship. The appengine-web.xml file was modified to ensure compatibility with the frontend component when deployed.
 
+Servlets developed in the backend must be routed to the prefix `/api/v1` in the `@WebServlet` annotation, e.g.:
+```
+@WebServlet("/api/v1/test-servlet")
+public class DataServlet extends HttpServlet { ... }
+```
+
+The servlet can then be accessed from the frontend with a fetch request, e.g. `fetch('api/v1/test-servlet').then( ... )`.
+
 ## Styling
 The React Bootstrap tool was imported for use in the frontend. Available components can be found [here](https://react-bootstrap.github.io/components/alerts/).
 

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -30,6 +30,12 @@
       <version>4.12</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>com.google.firebase</groupId>
+      <artifactId>firebase-admin</artifactId>
+      <version>6.14.0</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/backend/src/main/java/com/google/slurp/servlets/ServerListener.java
+++ b/backend/src/main/java/com/google/slurp/servlets/ServerListener.java
@@ -1,0 +1,47 @@
+package com.google.slurp.servlets;
+
+import java.io.IOException;
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import javax.servlet.annotation.WebListener;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+
+/**
+ * Servlet context listener that is looked for whenever the backend server
+ * receives a startup or shutdown request.
+ */
+@WebListener
+public class ServerListener implements ServletContextListener {
+
+  /**
+   * {@inheritDoc}
+   *
+   * Initialize the Firebase Admin app for the server.
+   */
+  @Override
+  public void contextInitialized(ServletContextEvent event) {
+    System.out.println("Server initialized and starting up...");
+
+    try {
+      FirebaseOptions options = new FirebaseOptions.Builder()
+          .setCredentials(GoogleCredentials.getApplicationDefault())
+          .build();
+
+      FirebaseApp.initializeApp(options);
+    } catch (IOException error) {
+      System.err.println("Error obtaining the Application Default Credentials:");
+      error.printStackTrace();
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void contextDestroyed(ServletContextEvent event) {
+    System.out.println("Server destroyed and shutting down...");
+  }
+}

--- a/backend/src/main/java/com/google/slurp/servlets/ServerListener.java
+++ b/backend/src/main/java/com/google/slurp/servlets/ServerListener.java
@@ -15,7 +15,6 @@ import com.google.firebase.FirebaseOptions;
  */
 @WebListener
 public class ServerListener implements ServletContextListener {
-
   /**
    * {@inheritDoc}
    *
@@ -27,8 +26,8 @@ public class ServerListener implements ServletContextListener {
 
     try {
       FirebaseOptions options = new FirebaseOptions.Builder()
-          .setCredentials(GoogleCredentials.getApplicationDefault())
-          .build();
+                                    .setCredentials(GoogleCredentials.getApplicationDefault())
+                                    .build();
 
       FirebaseApp.initializeApp(options);
     } catch (IOException error) {

--- a/backend/src/main/java/com/google/slurp/servlets/ServerListener.java
+++ b/backend/src/main/java/com/google/slurp/servlets/ServerListener.java
@@ -1,13 +1,12 @@
 package com.google.slurp.servlets;
 
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
 import java.io.IOException;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 import javax.servlet.annotation.WebListener;
-
-import com.google.auth.oauth2.GoogleCredentials;
-import com.google.firebase.FirebaseApp;
-import com.google.firebase.FirebaseOptions;
 
 /**
  * Servlet context listener that is looked for whenever the backend server


### PR DESCRIPTION
### What is a quick description of the change?

Initializes a Firebase admin app in the backend.

### Is this fixing an issue?

Starts work on #63.

### Are there more details that are relevant?

The Firebase Admin dependency was added to the pom.xml file, and a ServletContextListener class was created that performs actions on startup and shutdown of the backend server. On startup, the Firebase Admin app was initialized, ensuring that only one instance of a Firebase Admin app is running at any given time.

The README was also updated with some details on how to develop servlets for the backend.

### Check lists (check `x` in `[ ]` of list items)

- [  ] Test written/updating
- [  ] Tests passing
- [x] Coding style (indentation, etc)

No logic written, just setup.

### Any additional comments?
